### PR TITLE
fix: update headline styling for light mode

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -5,7 +5,7 @@
             <div class="max-w-screen-xl px-4 pt-32 mx-auto text-center lg:pt-48 lg:px-12">
                 <h1
                     class="flex flex-col md:flex-row items-center justify-center gap-x-2 mb-4 font-extrabold tracking-tight text-gray-900 text-4xl md:text-5xl lg:text-6xl dark:text-white">
-                    <span class="text-white h-[2.5rem] md:h-[3.5rem] lg:h-[4rem]">GitHub
+                    <span class="dark:text-white h-[2.5rem] md:h-[3.5rem] lg:h-[4rem]">GitHub
                         Workflows</span>
                     <span class="text-vscode-link h-[2.5rem] md:h-[3.5rem] lg:h-[4rem]" #reimagined></span>
                 </h1>


### PR DESCRIPTION
The website's headline wasn't responsive to the theme chosen, so I fixed that. 

Thanks.